### PR TITLE
feat(plugin): add hashcorp vault plugin

### DIFF
--- a/cmd/plugin/hashcorp_vault/main.go
+++ b/cmd/plugin/hashcorp_vault/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"github.com/devstream-io/devstream/internal/pkg/plugin/hashcorp_vault"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+// NAME is the name of this DevStream plugin.
+const NAME = "vault"
+
+// Plugin is the type used by DevStream core. It's a string.
+type Plugin string
+
+// Create implements the create of vault.
+func (p Plugin) Create(options map[string]interface{}) (map[string]interface{}, error) {
+	return hashcorp_vault.Create(options)
+}
+
+// Update implements the update of vault.
+func (p Plugin) Update(options map[string]interface{}) (map[string]interface{}, error) {
+	return hashcorp_vault.Update(options)
+}
+
+// Delete implements the delete of vault.
+func (p Plugin) Delete(options map[string]interface{}) (bool, error) {
+	return hashcorp_vault.Delete(options)
+}
+
+// Read implements the read of vault.
+func (p Plugin) Read(options map[string]interface{}) (map[string]interface{}, error) {
+	return hashcorp_vault.Read(options)
+}
+
+// DevStreamPlugin is the exported variable used by the DevStream core.
+var DevStreamPlugin Plugin
+
+func main() {
+	log.Infof("%T: %s is a plugin for DevStream. Use it with DevStream.\n", NAME, DevStreamPlugin)
+}

--- a/internal/pkg/plugin/hashcorp_vault/create.go
+++ b/internal/pkg/plugin/hashcorp_vault/create.go
@@ -1,0 +1,55 @@
+package hashcorp_vault
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/devstream-io/devstream/pkg/util/helm"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+// Create creates vault with provided options.
+func Create(options map[string]interface{}) (map[string]interface{}, error) {
+	// 1. decode options
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return nil, err
+	}
+
+	if errs := helm.Validate(opts.GetHelmParam()); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return nil, fmt.Errorf("opts are illegal")
+	}
+
+	// 2. deal with ns
+	if err := DealWithNsWhenInstall(&opts); err != nil {
+		return nil, err
+	}
+
+	var retErr error
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		if err := DealWithNsWhenInterruption(&opts); err != nil {
+			log.Errorf("Failed to deal with namespace: %s.", err)
+		}
+		log.Debugf("Deal with namespace when interruption succeeded.")
+	}()
+
+	// 3. install or upgrade
+	if retErr = InstallOrUpgradeChart(&opts); retErr != nil {
+		return nil, retErr
+	}
+
+	// 4. fill the return map
+	retMap := GetStaticState().ToStringInterfaceMap()
+	log.Debugf("Return map: %v", retMap)
+
+	return retMap, nil
+}

--- a/internal/pkg/plugin/hashcorp_vault/delete.go
+++ b/internal/pkg/plugin/hashcorp_vault/delete.go
@@ -1,0 +1,55 @@
+package hashcorp_vault
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/helm"
+	"github.com/devstream-io/devstream/pkg/util/k8s"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+func Delete(options map[string]interface{}) (bool, error) {
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return false, err
+	}
+
+	if errs := helm.Validate(opts.GetHelmParam()); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return false, fmt.Errorf("opts are illegal")
+	}
+
+	h, err := helm.NewHelm(opts.GetHelmParam())
+	if err != nil {
+		return false, err
+	}
+
+	log.Info("Uninstalling openldap helm chart.")
+	if err = h.UninstallHelmChartRelease(); err != nil {
+		return false, err
+	}
+
+	if err := dealWithNsWhenUninstall(&opts); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func dealWithNsWhenUninstall(opts *Options) error {
+	if !opts.CreateNamespace {
+		return nil
+	}
+
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return err
+	}
+
+	return kubeClient.DeleteNamespace(opts.Chart.Namespace)
+}

--- a/internal/pkg/plugin/hashcorp_vault/read.go
+++ b/internal/pkg/plugin/hashcorp_vault/read.go
@@ -1,0 +1,63 @@
+package hashcorp_vault
+
+import (
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+	"k8s.io/utils/strings/slices"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/helm"
+	"github.com/devstream-io/devstream/pkg/util/k8s"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+const (
+	DefaultNamespace = "devstream-vault-test1"
+)
+
+func Read(options map[string]interface{}) (map[string]interface{}, error) {
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return nil, err
+	}
+
+	if errs := helm.Validate(opts.GetHelmParam()); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return nil, fmt.Errorf("opts are illegal")
+	}
+
+	namespace := opts.Chart.Namespace
+	if namespace == "" {
+		namespace = DefaultNamespace
+	}
+
+	kubeClient, err := k8s.NewClient()
+	if err != nil {
+		return nil, err
+	}
+
+	dps, err := kubeClient.ListDeployments(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	retState := &helm.InstanceState{}
+	for _, dp := range dps {
+		dpName := dp.GetName()
+		if !slices.Contains(DefaultDeploymentList, dpName) {
+			log.Infof("Found unknown deployment: %s.", dpName)
+		}
+
+		ready := kubeClient.IsDeploymentReady(&dp)
+		retState.Workflows.AddDeployment(dpName, ready)
+		log.Debugf("The deployment %s is %t.", dp.GetName(), ready)
+	}
+
+	retMap := retState.ToStringInterfaceMap()
+	log.Debugf("Return map: %v.", retMap)
+
+	return retMap, nil
+}

--- a/internal/pkg/plugin/hashcorp_vault/update.go
+++ b/internal/pkg/plugin/hashcorp_vault/update.go
@@ -1,0 +1,38 @@
+package hashcorp_vault
+
+import (
+	"fmt"
+
+	"github.com/devstream-io/devstream/pkg/util/helm"
+
+	"github.com/mitchellh/mapstructure"
+
+	. "github.com/devstream-io/devstream/internal/pkg/plugin/common/helm"
+	"github.com/devstream-io/devstream/pkg/util/log"
+)
+
+func Update(options map[string]interface{}) (map[string]interface{}, error) {
+	// 1. decode options
+	var opts Options
+	if err := mapstructure.Decode(options, &opts); err != nil {
+		return nil, err
+	}
+
+	if errs := helm.Validate(opts.GetHelmParam()); len(errs) != 0 {
+		for _, e := range errs {
+			log.Errorf("Options error: %s.", e)
+		}
+		return nil, fmt.Errorf("opts are illegal")
+	}
+
+	// 2. install or upgrade
+	if err := InstallOrUpgradeChart(&opts); err != nil {
+		return nil, err
+	}
+
+	// 3. fill the return map
+	retMap := GetStaticState().ToStringInterfaceMap()
+	log.Debugf("Return map: %v", retMap)
+
+	return retMap, nil
+}

--- a/internal/pkg/show/config/config.go
+++ b/internal/pkg/show/config/config.go
@@ -24,6 +24,7 @@ var pluginDefaultConfigs = map[string]string{
 	"openldap":                       plugin.OpenldapDefaultConfig,
 	"trello-github-integ":            plugin.TrelloGithubDefaultConfig,
 	"trello":                         plugin.TrelloDefaultConfig,
+	"hashcorp_vault":                 plugin.HashCorpVaultDefaultConfig,
 }
 
 func Show() error {

--- a/internal/pkg/show/config/plugin/hashcorp_vault.go
+++ b/internal/pkg/show/config/plugin/hashcorp_vault.go
@@ -1,0 +1,34 @@
+package plugin
+
+var HashCorpVaultDefaultConfig = `tools:
+- name: vault
+  # name of the plugin
+  plugin: vault
+  options:
+    # need to create the namespace or not, default: false
+    create_namespace: true
+    repo:
+		# name of the Helm repo
+      name: hashicorp
+      # url of the Helm repo
+      url: https://helm.releases.hashicorp.com
+    # Helm chart information
+    chart:
+      # name of the chart
+      chart_name: hashicorp/vault
+      # release name of the chart
+      release_name: vault
+      # k8s namespace where Vault will be installed
+      namespace: devstreamtest1
+      # whether to wait for the release to be deployed or not
+      wait: true
+      # the time to wait for any individual Kubernetes operation (like Jobs for hooks). This defaults to 5m0s
+      timeout: 5m
+      values_yaml: |
+      server:
+        affinity: ""
+        ha:
+          enabled: true
+        namespaceSelector:
+          matchLabels:
+            injection: enabled`


### PR DESCRIPTION
# Summary

<!--
Thanks for submitting a PR!

We appreciate you spending the time to work on these changes.

Please fill out as many sections below as possible.
-->

## Key Points

- [ ] This is a breaking change.
- [x] Documentation (new or existing) is updated.

## Description

Add hashcorp plugin via helm install

### Related Issues

Will this PR close any open issues? If yes, would you please mention the issue(s) here?

### Current Behavior

Describe the current behavior of this issue, if relevant.

### New Behavior

Describe the newly updated behavior, if relevant.

### Screenshots

<img width="573" alt="image" src="https://user-images.githubusercontent.com/961094/164986982-98cb787d-de56-410b-b060-5835bc93d5b8.png">


### Other Information

Currently this plugin is only used to install, after installation vault pod need init storage by manual. Maybe we can using k8s apiserver, make the init step automatic.
